### PR TITLE
Bump Go version to 1.26.0 to resolve stdlib CVEs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # Variables
-TAG := v1.1.1
+TAG := v1.1.2
 LDFLAGS := -X main.buildVersion=$(TAG)
 GO111MODULE := on
-GO_VERSION := 1.22.7
+GO_VERSION := 1.26.0
 BINARY_NAME := minica
 
 # Default target

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/jsha/minica
 
-go 1.22
+go 1.26


### PR DESCRIPTION
## Description

Bumps the Go build version from 1.22.7 to 1.26.0 and tags a new release v1.1.2 to resolve critical and high severity CVEs in the Go standard library.

## Related
- https://github.com/astronomer/security-issues/issues/9225
- https://github.com/astronomer/security-issues/issues/9184